### PR TITLE
fix: resolve warning publishing configuration

### DIFF
--- a/countryPicker/build.gradle.kts
+++ b/countryPicker/build.gradle.kts
@@ -41,6 +41,12 @@ android {
       isIncludeAndroidResources = true
     }
   }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+      withJavadocJar()
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
### Changes Made

- Remove warning publishing on `build.gradle.kts` configuration
